### PR TITLE
Fix npm build with missing .git

### DIFF
--- a/build/version_plugin.js
+++ b/build/version_plugin.js
@@ -1,5 +1,13 @@
-const commit = require('git-rev-sync').short();
+const gitRevSync = require('git-rev-sync');
 const pkg = require('../package.json');
+
+let commit = 'unknown';
+
+try {
+  commit = gitRevSync.short();
+} catch (e) {
+  console.warn('Error fetching current git commit: ' + e);
+}
 
 const version = JSON.stringify({
   commit,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ const path = require('path');
 const webpack = require('webpack');
 const CopyPlugin = require('copy-webpack-plugin');
 const ManifestPlugin = require('webpack-manifest-plugin');
-//const VersionPlugin = require('./build/version_plugin');
+const VersionPlugin = require('./build/version_plugin');
 const AndroidIndexPlugin = require('./build/android_index_plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
 
@@ -194,7 +194,7 @@ const web = {
     new ExtractTextPlugin({
       filename: '[name].[md5:contenthash:8].css'
     }),
-//  new VersionPlugin(), // used for the /__version__ route
+    new VersionPlugin(), // used for the /__version__ route
     new AndroidIndexPlugin(),
     new ManifestPlugin() // used by server side to resolve hashed assets
   ],


### PR DESCRIPTION
Because of the implementation of codeamp's docker builder, `.git` directory is not present in our images.

The npm build requires `.git` in order to not blow up, although the information retrieved from it (current commit hash) is not essential to operate the app and is only used in this  [info/diagnostic route](https://github.com/mozilla/send/issues/33). 

This is my attempt to allow `.git`less builds to pass, while maybe being acceptable upstream.