### PR TITLE
EPLT-924: Send event counts to statsd

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16607,6 +16607,11 @@
         }
       }
     },
+    "statsd-client": {
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/statsd-client/-/statsd-client-0.4.4.tgz",
+      "integrity": "sha512-GjAReJDNZomTTTaIaDuDddWknHO2GXmXS/9JKy6iQFOHNSQ4yeaRGP18oNgahl+c3XTUfUWBYIUnipznNh5Vww=="
+    },
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",

--- a/package.json
+++ b/package.json
@@ -157,6 +157,7 @@
     "node-fetch": "^2.6.0",
     "redis": "^2.8.0",
     "selenium-standalone": "^6.15.6",
+    "statsd-client": "^0.4.4",
     "ua-parser-js": "^0.7.20"
   },
   "availableLanguages": [

--- a/server/config.js
+++ b/server/config.js
@@ -215,6 +215,21 @@ const conf = convict({
     format: String,
     default: '',
     env: 'SURVEY_URL'
+  },
+  statsd_host: {
+    format: String,
+    default: 'localhost',
+    env: 'STATSD_HOST'
+  },
+  statsd_port: {
+    format: String,
+    default: '8124',
+    env: 'STATSD_PORT'
+  },
+  statsd_prefix: {
+    format: String,
+    default: 'sendr',
+    env: 'STATSD_PREFIX'
   }
 });
 

--- a/server/config.js
+++ b/server/config.js
@@ -222,8 +222,8 @@ const conf = convict({
     env: 'STATSD_HOST'
   },
   statsd_port: {
-    format: String,
-    default: '8124',
+    format: 'port',
+    default: 8125,
     env: 'STATSD_PORT'
   },
   statsd_prefix: {

--- a/server/routes/metrics.js
+++ b/server/routes/metrics.js
@@ -31,6 +31,7 @@ function sendToStatsd(data) {
       metric_name += `_${e.event_properties.status}`;
     }
 
+    console.log('event: ' + metric_name);
     client.increment(metric_name);
   });
 }
@@ -44,6 +45,7 @@ module.exports = async function(req, res) {
 
     res.sendStatus(status);
   } catch (e) {
+    console.log(e);
     res.sendStatus(500);
   }
 };

--- a/server/routes/metrics.js
+++ b/server/routes/metrics.js
@@ -1,21 +1,47 @@
 const { sendBatch, clientEvent } = require('../amplitude');
+const statsdClient = require('statsd-client');
+const config = require('../config');
+
+async function sendToAmplitude(data, req) {
+  const deltaT = Date.now() - data.now;
+  const events = data.events.map(e =>
+    clientEvent(
+      e,
+      req.ua,
+      data.lang,
+      data.session_id + deltaT,
+      deltaT,
+      data.platform,
+      req.ip
+    )
+  );
+  return sendBatch(events);
+}
+
+function sendToStatsd(data) {
+  let client = new statsdClient({
+    host: config.statsd_host,
+    port: config.statsd_port,
+    prefix: config.statsd_prefix
+  });
+
+  data.events.forEach(function(e) {
+    let metric_name = e.event_type;
+    if (e.event_properties.status) {
+      metric_name += `_${e.event_properties.status}`;
+    }
+
+    client.increment(metric_name);
+  });
+}
 
 module.exports = async function(req, res) {
   try {
     const data = JSON.parse(req.body); // see http://crbug.com/490015
-    const deltaT = Date.now() - data.now;
-    const events = data.events.map(e =>
-      clientEvent(
-        e,
-        req.ua,
-        data.lang,
-        data.session_id + deltaT,
-        deltaT,
-        data.platform,
-        req.ip
-      )
-    );
-    const status = await sendBatch(events);
+
+    sendToStatsd(data);
+    const status = await sendToAmplitude(data, req);
+
     res.sendStatus(status);
   } catch (e) {
     res.sendStatus(500);


### PR DESCRIPTION
By default, send sends to Amplitude. Now we'll push the same event metrics to Datadog via statsd at the same time. Eventually can be replaced with openmetrics.