### PR TITLE
[EPLT-1028] Update Checkr branding in webmanifest.js

### DIFF
--- a/server/routes/webmanifest.js
+++ b/server/routes/webmanifest.js
@@ -14,7 +14,7 @@ module.exports = function(req, res) {
       {
         src: assets.get('checkr_logo_white.png'),
         type: 'image/png',
-        sizes: '512x512'
+        sizes: '1200x400'
       }
     ],
     start_url: '/',

--- a/server/routes/webmanifest.js
+++ b/server/routes/webmanifest.js
@@ -2,17 +2,17 @@ const assets = require('../../common/assets');
 
 module.exports = function(req, res) {
   const manifest = {
-    name: 'Firefox Send',
-    short_name: 'Send',
+    name: 'Checkr Sendr',
+    short_name: 'Sendr',
     lang: req.language,
     icons: [
       {
-        src: assets.get('android-chrome-192x192.png'),
+        src: assets.get('checkr-favicon-150x150.png'),
         type: 'image/png',
-        sizes: '192x192'
+        sizes: '150x150'
       },
       {
-        src: assets.get('android-chrome-512x512.png'),
+        src: assets.get('checkr_logo_white.png'),
         type: 'image/png',
         sizes: '512x512'
       }


### PR DESCRIPTION
- 'Chrome Apps' are not extensions
- Chrome Apps, and possibly other browsers, look at
  the manifest that appears on the webpage for information
  on how to package the website into a standalone app.

  see:
  - layout.js for:
          <link rel="manifest" href="/app.webmanifest" />
  - index.js provides the route
  - webmanifest.js provides the manifest definition

![Screen Shot 2019-12-30 at 3 22 02 PM](https://user-images.githubusercontent.com/52683398/71603030-38c70d00-2b18-11ea-972c-c22cc4f84c2e.png)
