### PR TITLE
Remove fxa-geodb will fix failed to download cities-db.mmdb from geolite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2143,7 +2143,7 @@
       "requires": {
         "@dannycoates/elliptic": "^6.4.2",
         "asmcrypto.js": "^0.22.0",
-        "webcrypto-core": "github:dannycoates/webcrypto-core#8e0152a66d3ae6329cf080ccb3085eb06637070f"
+        "webcrypto-core": "github:dannycoates/webcrypto-core"
       }
     },
     "@fluent/bundle": {
@@ -3469,11 +3469,6 @@
       "requires": {
         "tweetnacl": "^0.14.3"
       }
-    },
-    "big-integer": {
-      "version": "1.6.41",
-      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.41.tgz",
-      "integrity": "sha512-d5AT9lMTYJ/ZE/4gzxb+5ttPcRWljVsvv7lF1w9KzkPhVUhBtHrjDo1J8swfZKepfLsliDhYa31zRYwcD0Yg9w=="
     },
     "big.js": {
       "version": "5.2.2",
@@ -4929,14 +4924,6 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
-      }
-    },
-    "cron": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/cron/-/cron-1.5.0.tgz",
-      "integrity": "sha512-j7zMFLrcSta53xqOvETUt8ge+PM14GtF47gEGJJeVlM6qP24/eWHSgtiWiEiKBR2sHS8xZaBQZq4D7vFXg8dcQ==",
-      "requires": {
-        "moment-timezone": "^0.5.x"
       }
     },
     "cross-env": {
@@ -8176,26 +8163,6 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
-    "fxa-geodb": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/fxa-geodb/-/fxa-geodb-1.0.4.tgz",
-      "integrity": "sha512-f+uNgA+6OxmLAHhZvMztwPrByhkaVmSrKcb5Q1TI7Zz/onSQPYCJs388are7nWQdXI94pncqmSPxmT9kOUllEA==",
-      "requires": {
-        "bluebird": "3.5.2",
-        "cron": "1.5.0",
-        "maxmind": "2.8.0",
-        "mkdirp": "0.5.1",
-        "mozlog": "2.2.0",
-        "request": "2.88.0"
-      },
-      "dependencies": {
-        "bluebird": {
-          "version": "3.5.2",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-          "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
-        }
-      }
-    },
     "gaxios": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.1.0.tgz",
@@ -11070,15 +11037,6 @@
       "integrity": "sha512-pWB896KPGSGkp1XtyzRBftpTzwSOL0Gfk0wLvxt4f2mgzjY19o0LxJ3U25vNWTzsh7da+KTbuXQoQ3lOJZ8WHw==",
       "dev": true
     },
-    "maxmind": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/maxmind/-/maxmind-2.8.0.tgz",
-      "integrity": "sha512-U3/jQRUoMf4pQ/Tm7JNtGRaM9z82fATB2TiGgs0kEKMPZn/UbOnlyGMRItJ2+KWrwjz9a7PqRzy3/haq9XfUOQ==",
-      "requires": {
-        "big-integer": "^1.6.31",
-        "tiny-lru": "^1.6.1"
-      }
-    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -11650,19 +11608,6 @@
       "resolved": "https://registry.npmjs.org/module-not-found-error/-/module-not-found-error-1.0.1.tgz",
       "integrity": "sha1-z4tP9PKWQGdNbN0CsOO8UjwrvcA=",
       "dev": true
-    },
-    "moment": {
-      "version": "2.22.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
-      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
-    },
-    "moment-timezone": {
-      "version": "0.5.23",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.23.tgz",
-      "integrity": "sha512-WHFH85DkCfiNMDX5D3X7hpNH3/PUhjTGcD0U1SgfBGZxJ3qUmJh5FdvaFjcClxOvB3rzdfj4oRffbI38jEnC1w==",
-      "requires": {
-        "moment": ">= 2.9.0"
-      }
     },
     "morgan": {
       "version": "1.9.1",
@@ -17636,11 +17581,6 @@
       "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
       "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q=",
       "dev": true
-    },
-    "tiny-lru": {
-      "version": "1.6.4",
-      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-1.6.4.tgz",
-      "integrity": "sha512-Et+J3Css66XPSLWjLF9wmgbECsGiExlEL+jxsFerTQF6N6dpxswDTPAfIrAbQKO5c1uhgq2xvo5zMk1W+kBDNA=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -149,7 +149,6 @@
     "configstore": "github:dannycoates/configstore#master",
     "convict": "^5.2.0",
     "express": "^4.17.1",
-    "fxa-geodb": "^1.0.4",
     "helmet": "^3.21.2",
     "mkdirp": "^0.5.1",
     "morgan": "^1.9.1",

--- a/server/amplitude.js
+++ b/server/amplitude.js
@@ -1,5 +1,4 @@
 const crypto = require('crypto');
-const geoip = require('fxa-geodb')();
 const fetch = require('node-fetch');
 const config = require('./config');
 const pkg = require('../package.json');
@@ -21,12 +20,8 @@ function userId(fileId, ownerId) {
   return hash.digest('hex').substring(32);
 }
 
-function location(ip) {
-  try {
-    return geoip(ip);
-  } catch (e) {
-    return {};
-  }
+function location(_ip) {
+  return {};
 }
 
 function statUploadEvent(data) {

--- a/server/amplitude.js
+++ b/server/amplitude.js
@@ -20,16 +20,11 @@ function userId(fileId, ownerId) {
   return hash.digest('hex').substring(32);
 }
 
-function location(_ip) {
-  return {};
-}
-
 function statUploadEvent(data) {
-  const loc = location(data.ip);
   const event = {
     session_id: -1,
-    country: loc.country,
-    region: loc.state,
+    country: undefined,
+    region: undefined,
     user_id: userId(data.id, data.owner),
     app_version: pkg.version,
     time: truncateToHour(Date.now()),
@@ -49,11 +44,10 @@ function statUploadEvent(data) {
 }
 
 function statDownloadEvent(data) {
-  const loc = location(data.ip);
   const event = {
     session_id: -1,
-    country: loc.country,
-    region: loc.state,
+    country: undefined,
+    region: undefined,
     user_id: userId(data.id, data.owner),
     app_version: pkg.version,
     time: truncateToHour(Date.now()),
@@ -69,11 +63,10 @@ function statDownloadEvent(data) {
 }
 
 function statDeleteEvent(data) {
-  const loc = location(data.ip);
   const event = {
     session_id: -1,
-    country: loc.country,
-    region: loc.state,
+    country: undefined,
+    region: undefined,
     user_id: userId(data.id, data.owner),
     app_version: pkg.version,
     time: truncateToHour(Date.now()),
@@ -88,8 +81,7 @@ function statDeleteEvent(data) {
   return sendBatch([event]);
 }
 
-function clientEvent(event, ua, language, session_id, deltaT, platform, ip) {
-  const loc = location(ip);
+function clientEvent(event, ua, language, session_id, deltaT, platform, _ip) {
   const ep = event.event_properties || {};
   const up = event.user_properties || {};
   const event_properties = {
@@ -125,7 +117,8 @@ function clientEvent(event, ua, language, session_id, deltaT, platform, ip) {
   };
   return {
     app_version: pkg.version,
-    country: loc.country,
+    country: undefined,
+    region: undefined,
     device_id: event.device_id,
     event_properties,
     event_type: event.event_type,
@@ -133,7 +126,6 @@ function clientEvent(event, ua, language, session_id, deltaT, platform, ip) {
     os_name: ua.os.name,
     os_version: ua.os.version,
     platform,
-    region: loc.state,
     session_id,
     time: event.time + deltaT,
     user_id: event.user_id,


### PR DESCRIPTION
[Background]
fxa-geodb is being [deprecated](https://github.com/mozilla/fxa/issues/3773). geolite/geolite2 maxmind made an announcement recently that they are requiring account credentials to access geolite data. unsure whether geolite.maxmind.com will remain the same url or they are going to geolite2.maxmind.com for this

[Solution]
In any case, we are not using the geoip / location anyways, nor are we using amplitude. Seems functionally safe to remove. Might introduce minor merge conflicts in only these files changed down the road. 

[Testing]
Ran `npm install`
Tested with `npm start`
       and with `docker-compose up`

[Notes]
https://github.com/mozilla/fxa-geodb
 - being deprecated and introduced into the main 'fxa' 
https://github.com/mozilla/fxa

If we want to there is a public backup of the data located on S3 here:
https://fxa-geodb.s3-us-west-2.amazonaws.com/cities-db.mmdb.gz
Seems to be maintained by Mozilla: https://github.com/mozilla/fxa/pull/3774